### PR TITLE
Keras 2.2.0 Applications Decoupling

### DIFF
--- a/keras_eval/utils.py
+++ b/keras_eval/utils.py
@@ -1,12 +1,13 @@
-import os
-import keras
 import json
+import keras.models
 import numpy as np
 import scipy
+import os
+import tensorflow as tf
+
+from keras_applications import mobilenet
 from keras_model_specs import ModelSpec
 from keras.preprocessing import image
-from keras.applications import mobilenet
-import tensorflow as tf
 
 
 def create_default_custom_objects():
@@ -15,7 +16,7 @@ def create_default_custom_objects():
     Returns: Default custom objects for Keras models supported in keras.applications
 
     '''
-    return {'relu6': mobilenet.relu6, 'DepthwiseConv2D': mobilenet.DepthwiseConv2D, "tf": tf}
+    return {'relu6': mobilenet.relu6, "tf": tf}
 
 
 def load_multi_model(models_dir, custom_objects=None):

--- a/setup.py
+++ b/setup.py
@@ -5,14 +5,14 @@ from setuptools import setup, find_packages
 
 setup(
     name='keras-eval',
-    version='0.0.9',
+    version='0.0.10',
     description='A evaluation abstraction for Keras models.',
     author='Triage Technologies Inc.',
     author_email='ai@triage.com',
     url='https://www.triage.com/',
     packages=find_packages(exclude=['tests', '.cache', '.venv', '.git', 'dist']),
     install_requires=[
-        'Keras>=2.1.6',
+        'Keras>=2.2.0',
         'h5py',
         'tensorflow',
         'Pillow',

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -1,7 +1,8 @@
-import os
 import json
 import numpy as np
+import os
 import pytest
+import tensorflow as tf
 
 from keras_eval.eval import Evaluator
 

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -2,7 +2,6 @@ import json
 import numpy as np
 import os
 import pytest
-import tensorflow as tf
 
 from keras_eval.eval import Evaluator
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,10 +1,11 @@
 import keras_eval.utils as utils
 import numpy as np
-from keras.applications import mobilenet
-import tensorflow as tf
-import pytest
 import os
+import pytest
+import tensorflow as tf
+
 from keras_model_specs import ModelSpec
+from keras_applications import mobilenet
 
 
 @pytest.fixture('session')
@@ -29,7 +30,9 @@ def model_spec_mobilenet():
 
 
 def test_load_model():
-    custom_objects = {'relu6': mobilenet.relu6, 'DepthwiseConv2D': mobilenet.DepthwiseConv2D, "tf": tf}
+    import pdb
+    pdb.set_trace()
+    custom_objects = {'relu6': mobilenet.relu6, "tf": tf}
     model_path = 'tmp/fixtures/models/mobilenet_1/mobilenet_v1.h5'
     model_spec_path = 'tmp/fixtures/models/mobilenet_2/model_spec.json'
 
@@ -44,7 +47,7 @@ def test_load_model():
 
 def test_load_model_ensemble():
     ensemble_dir = 'tmp/fixtures/models'
-    custom_objects = {'relu6': mobilenet.relu6, 'DepthwiseConv2D': mobilenet.DepthwiseConv2D, "tf": tf}
+    custom_objects = {'relu6': mobilenet.relu6, "tf": tf}
     models = utils.load_multi_model(ensemble_dir, custom_objects=custom_objects)
     assert models
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -30,8 +30,6 @@ def model_spec_mobilenet():
 
 
 def test_load_model():
-    import pdb
-    pdb.set_trace()
     custom_objects = {'relu6': mobilenet.relu6, "tf": tf}
     model_path = 'tmp/fixtures/models/mobilenet_1/mobilenet_v1.h5'
     model_spec_path = 'tmp/fixtures/models/mobilenet_2/model_spec.json'


### PR DESCRIPTION
- Depthwise layer is supported now
- They have decoupled models from the original keras package