### PR TITLE
Bump version for new_metrics

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='keras-eval',
-    version='0.0.10',
+    version='0.0.11',
     description='A evaluation abstraction for Keras models.',
     author='Triage Technologies Inc.',
     author_email='ai@triage.com',


### PR DESCRIPTION
I forgot to bump the version in https://github.com/triagemd/keras-eval/pull/23.