### PR TITLE
Use evaluation id instead of model_path string

### DIFF
--- a/keras_eval/eval.py
+++ b/keras_eval/eval.py
@@ -460,7 +460,7 @@ class Evaluator(object):
             raise ValueError('results parameter is None, please run a evaluation first')
 
         if mode is 'average':
-            df = pd.DataFrame({'model': os.path.basename(self.model_path)}, index=range(1))
+            df = pd.DataFrame({'model': self.id}, index=range(1))
 
             for metric in self.results['average'].keys():
                 if metric is not 'confusion_matrix':

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='keras-eval',
-    version='0.0.14',
+    version='0.0.15',
     description='A evaluation abstraction for Keras models.',
     author='Triage Technologies Inc.',
     author_email='ai@triage.com',


### PR DESCRIPTION
Use evaluation `id` instead of the model path as a eval identifier (note this is wrong for an ensemble of models). 