### PR TITLE
Remove dependency on tensorflow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,6 @@ autoflake
 pep8
 autopep8
 
+tensorflow
 stored
 backports.tempfile

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ setup(
     install_requires=[
         'Keras>=2.2.0',
         'h5py',
-        'tensorflow',
         'Pillow',
         'scipy',
         'numpy',


### PR DESCRIPTION
`tensorflow` and `tensorflow-gpu` conflict, so we should avoid expressing a dependency on either in any `setup.py` -- instead, the readme or etc. should indicate to the user they need to install tensorflow themselves