### PR TITLE
Error computing TN, FP, FN, TP when any is 0

### DIFF
--- a/keras_eval/metrics.py
+++ b/keras_eval/metrics.py
@@ -67,10 +67,11 @@ def metrics_top_k(y_probs, y_true, concepts, top_k, round_decimals=7):
 
     # top-1 metrics
     one_hot_top_1_preds = to_categorical(top_preds[:, 0:1])
+
     for idx, concept in enumerate(concepts):
         total_samples_concept = np.sum(y_true == idx)
 
-        tn, fp, fn, tp = confusion_matrix(one_hot_y_true[:, idx], one_hot_top_1_preds[:, idx]).astype(
+        tn, fp, fn, tp = confusion_matrix(one_hot_y_true[:, idx], one_hot_top_1_preds[:, idx], labels=[0, 1]).astype(
             np.float32).ravel()
 
         sensitivity = round(utils.safe_divide(tp, tp + fn), round_decimals)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='keras-eval',
-    version='0.0.16',
+    version='0.0.18',
     description='A evaluation abstraction for Keras models.',
     author='Triage Technologies Inc.',
     author_email='ai@triage.com',


### PR DESCRIPTION
Fix https://github.com/triagemd/keras-eval/issues/37.

The main issue (not checked in the tests) was if any of the `TN`, `FP`, `FN`, `TP` were zero, the `confusion_matrix` was not be able to `.rapel()` properly the four different values.