### PR TITLE
Fix AUROC computation

### DIFF
--- a/keras_eval/metrics.py
+++ b/keras_eval/metrics.py
@@ -90,7 +90,7 @@ def metrics_top_k(y_probs, y_true, concepts, top_k, round_decimals=7):
         average_fdr.append(fdr * total_samples_concept)
 
         fpr, tpr, _ = roc_curve(y_true, y_probs[:, idx], pos_label=idx)
-        auroc = round(np.mean(tpr), round_decimals)
+        auroc = np.trapz(tpr, fpr)
         average_auroc.append(auroc * total_samples_concept)
 
         metrics['individual'].append({

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -171,7 +171,7 @@ def test_show_results(evaluator_mobilenet):
     assert average_df['model'][0] == 'mobilenet_v1.h5'
     assert average_df['accuracy'][0] == average_df['precision'][0] == average_df['sensitivity'][0] \
         == average_df['f1_score'][0] == 1.0
-    assert average_df['auroc'][0] == 0.833
+    assert average_df['auroc'][0] == 1.0
     assert average_df['fdr'][0] == 0.0
 
     individual_df = evaluator_mobilenet.show_results(mode='individual')
@@ -182,4 +182,4 @@ def test_show_results(evaluator_mobilenet):
     assert individual_df['f1_score'][0] == individual_df['f1_score'][1] == 1.0
     assert individual_df['TP'][0] == individual_df['TP'][1] == 2
     assert individual_df['FP'][0] == individual_df['FP'][1] == individual_df['FN'][1] == individual_df['FN'][1] == 0
-    assert individual_df['AUROC'][0] == individual_df['AUROC'][1] == 0.833
+    assert individual_df['AUROC'][0] == individual_df['AUROC'][1] == 1.0


### PR DESCRIPTION
Fix https://github.com/triagemd/keras-eval/issues/42:
- Currently we're just `np.mean(tpr)` to compute the AUROC.
- Corrected by computing the integrate along the `TPR` axis using the composite trapezoidal rule.

e.g. 
`plt.plot(fpr, tpr)`:

![download](https://user-images.githubusercontent.com/5657335/42387821-966e2dec-8111-11e8-9c5a-1ae553de5606.png)

**Before**: `auroc = np.mean(tpr) = 0.6914285714285714`
**Now**: `auroc = np.trapz(tpr, fpr) = 0.8589511754068717`

Now results match to [`sklearn.metrics.roc_auc_score`](http://scikit-learn.org/stable/modules/generated/sklearn.metrics.roc_auc_score.html). 