### PR TITLE
Replace relu6 with ReLU layers

### DIFF
--- a/keras_eval/utils.py
+++ b/keras_eval/utils.py
@@ -31,7 +31,7 @@ def create_default_custom_objects():
     Returns: Default custom objects for Keras models supported in keras_applications
 
     '''
-    return {'relu6': mobilenet.relu6, "tf": tf, 'Scale': custom_layers.Scale}
+    return {'relu6': mobilenet.layers.ReLU(6, name='relu6'), "tf": tf, 'Scale': custom_layers.Scale}
 
 
 def load_multi_model(models_dir, custom_objects=None):

--- a/setup.py
+++ b/setup.py
@@ -5,14 +5,14 @@ from setuptools import setup, find_packages
 
 setup(
     name='keras-eval',
-    version='0.0.25',
+    version='0.0.26',
     description='An evaluation abstraction for Keras models.',
     author='Triage Technologies Inc.',
     author_email='ai@triage.com',
     url='https://www.triage.com/',
     packages=find_packages(exclude=['tests', '.cache', '.venv', '.git', 'dist']),
     install_requires=[
-        'Keras>=2.2.0',
+        'Keras>=2.2.2',
         'h5py',
         'Pillow',
         'scipy',

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -42,7 +42,7 @@ def test_round_list():
 
 
 def test_load_model():
-    custom_objects = {'relu6': mobilenet.relu6, "tf": tf}
+    custom_objects = {'relu6': mobilenet.layers.ReLU(6, name='relu6'), "tf": tf}
     model_path = 'tmp/fixtures/models/mobilenet_1/mobilenet_v1.h5'
     model_spec_path = 'tmp/fixtures/models/mobilenet_2/model_spec.json'
 
@@ -57,7 +57,7 @@ def test_load_model():
 
 def test_load_model_ensemble():
     ensemble_dir = 'tmp/fixtures/models'
-    custom_objects = {'relu6': mobilenet.relu6, "tf": tf}
+    custom_objects = {'relu6': mobilenet.layers.ReLU(6, name='relu6'), "tf": tf}
     models, specs = utils.load_multi_model(ensemble_dir, custom_objects=custom_objects)
     assert models
     assert specs
@@ -169,7 +169,7 @@ def test_show_results():
 
 def test_ensemble_models(test_image_path, model_spec_mobilenet):
     ensemble_dir = 'tmp/fixtures/models'
-    custom_objects = {'relu6': mobilenet.relu6, "tf": tf}
+    custom_objects = {'relu6': mobilenet.layers.ReLU(6, name='relu6'), "tf": tf}
     models, model_specs = utils.load_multi_model(ensemble_dir, custom_objects=custom_objects)
 
     with pytest.raises(ValueError) as exception:


### PR DESCRIPTION
From https://github.com/keras-team/keras/pull/10597/files, Keras `2.2.2` has stopped using `relu6` and instead now it's using `ReLU` layers.