### PR TITLE
Import mobilenet from keras.applications

### DIFF
--- a/keras_eval/eval.py
+++ b/keras_eval/eval.py
@@ -371,7 +371,7 @@ class Evaluator(object):
 
     def get_image_paths_by_prediction(self, probabilities, labels, concept_labels=None, image_paths=None):
         '''
-
+        Return the list of images given its predictions.
         Args:
             probabilities: Probabilities given by the model [n_samples,n_classes]
             labels: Ground truth labels (categorical)
@@ -384,7 +384,6 @@ class Evaluator(object):
                 'harmonic': predictions are obtained by a harmonic mean of all the probabilities
 
         Returns: A dictionary containing a list of images per confusion matrix square (relation ClassA_ClassB)
-
         '''
         self.combined_probabilities = utils.combine_probabilities(probabilities, self.combination_mode)
 

--- a/keras_eval/utils.py
+++ b/keras_eval/utils.py
@@ -10,7 +10,6 @@ from keras.layers import average, maximum
 from keras.models import Model, Input
 from keras.preprocessing import image
 from keras_model_specs import ModelSpec
-from keras_applications import mobilenet
 import keras_model_specs.models.custom_layers as custom_layers
 
 
@@ -31,7 +30,7 @@ def create_default_custom_objects():
     Returns: Default custom objects for Keras models supported in keras_applications
 
     '''
-    return {'relu6': mobilenet.layers.ReLU(6, name='relu6'), "tf": tf, 'Scale': custom_layers.Scale}
+    return {'tf': tf, 'Scale': custom_layers.Scale}
 
 
 def load_multi_model(models_dir, custom_objects=None):
@@ -41,7 +40,6 @@ def load_multi_model(models_dir, custom_objects=None):
     Args:
        models_path: a string indicating the directory were models are stored.
        custom_objects: dict mapping class names (or function names) of custom (non-Keras) objects to class/functions.
-                    e.g. for mobilenet models: {'relu6': mobilenet.relu6, 'DepthwiseConv2D': mobilenet.DepthwiseConv2D}
 
     Returns: List of models, list of model_specs
 
@@ -74,7 +72,6 @@ def load_model(model_path, specs_path=None, custom_objects=None):
         model_dir: Folder containing the model
         specs_path: If specified custom model_specs name, default `model_spec.json`
         custom_objects: dict mapping class names (or function names) of custom (non-Keras) objects to class/functions.
-                    e.g. for mobilenet models: {'relu6': mobilenet.relu6, 'DepthwiseConv2D': mobilenet.DepthwiseConv2D}
 
     Returns: keras model, model_spec object for that model
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ autoflake
 pep8
 autopep8
 
-tensorflow==1.10
+tensorflow
 stored
 backports.tempfile

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ autoflake
 pep8
 autopep8
 
-tensorflow
+tensorflow==1.10
 stored
 backports.tempfile

--- a/script/fetch-fixtures
+++ b/script/fetch-fixtures
@@ -4,12 +4,12 @@ set -e
 mkdir -p tmp/fixtures/models/ensemble/mobilenet_1/ tmp/fixtures/models/ensemble/mobilenet_2/
 
 cd tmp/fixtures/models/ensemble/mobilenet_1/
-  MODEL_URL="https://storage.googleapis.com/keras-eval-fixtures-c04aef45-46f3-42ae-910d-8dba8c4be026/mobilenet_v1.h5"
-if [ ! -f mobilenet_v1.h5 ]; then
+  MODEL_URL="https://storage.googleapis.com/triage-lab/models/animals/catdog-mobilenet.hdf5"
+if [ ! -f catdog-mobilenet.hdf5 ]; then
     wget $MODEL_URL
 fi
 cd ../mobilenet_2/
-if [ ! -f mobilenet_v1.h5 ]; then
+if [ ! -f catdog-mobilenet.hdf5 ]; then
     wget $MODEL_URL
 fi
 )
@@ -17,7 +17,7 @@ fi
 mkdir -p tmp/fixtures/models/single/
 
 cd tmp/fixtures/models/single/
-if [ ! -f animals_combine_classes.hdf5 ]; then
-    MODEL_URL="https://storage.googleapis.com/triage-lab/models/animals/animals_combine_classes.hdf5" 
+if [ ! -f animals-mobilenet.hdf5 ]; then
+    MODEL_URL="https://storage.googleapis.com/triage-lab/models/animals/animals-mobilenet.hdf5"
     wget $MODEL_URL
 fi

--- a/setup.py
+++ b/setup.py
@@ -5,14 +5,14 @@ from setuptools import setup, find_packages
 
 setup(
     name='keras-eval',
-    version='0.0.32',
+    version='0.0.33',
     description='An evaluation abstraction for Keras models.',
     author='Triage Technologies Inc.',
     author_email='ai@triage.com',
     url='https://www.triage.com/',
     packages=find_packages(exclude=['tests', '.cache', '.venv', '.git', 'dist']),
     install_requires=[
-        'Keras>=2.2.2',
+        'Keras>=2.2.0',
         'h5py',
         'Pillow',
         'scipy',
@@ -21,6 +21,6 @@ setup(
         'plotly',
         'matplotlib',
         'sklearn',
-        'keras-model-specs>=0.0.27',
+        'keras-model-specs>=0.0.28',
     ]
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,137 @@
+import os
+import json
+import pytest
+
+from keras_eval.eval import Evaluator
+from keras_model_specs import ModelSpec
+
+
+@pytest.fixture('session')
+def test_catdog_dataset_path():
+    return os.path.abspath(os.path.join('tests', 'files', 'catdog', 'test'))
+
+
+@pytest.fixture('session')
+def test_animals_dataset_path():
+    return os.path.abspath(os.path.join('tests', 'files', 'animals', 'test'))
+
+
+@pytest.fixture('session')
+def test_cat_folder():
+    return os.path.abspath(os.path.join('tests', 'files', 'catdog', 'test', 'cat'))
+
+
+@pytest.fixture('session')
+def test_dog_folder():
+    return os.path.abspath(os.path.join('tests', 'files', 'catdog', 'test', 'dog'))
+
+
+@pytest.fixture('session')
+def training_dict_file():
+    return os.path.abspath(os.path.join('tests', 'files', 'animals', 'dictionary.json'))
+
+
+@pytest.fixture('session')
+def test_image_path():
+    return os.path.abspath(os.path.join('tests', 'files', 'catdog', 'test', 'cat', 'cat-1.jpg'))
+
+
+@pytest.fixture('session')
+def test_ensemble_models_path():
+    return os.path.abspath(os.path.join('tmp', 'fixtures', 'models', 'ensemble'))
+
+
+@pytest.fixture('session')
+def test_catdog_mobilenet_model():
+    return os.path.abspath(
+        os.path.join('tmp', 'fixtures', 'models', 'ensemble', 'mobilenet_1', 'catdog-mobilenet.hdf5'))
+
+
+@pytest.fixture('session')
+def test_mobilenet_1_model_spec():
+    return os.path.abspath(os.path.join('tmp', 'fixtures', 'models', 'ensemble', 'mobilenet_1', 'model_spec.json'))
+
+
+@pytest.fixture('session')
+def test_mobilenet_2_model_spec():
+    return os.path.abspath(os.path.join('tmp', 'fixtures', 'models', 'ensemble', 'mobilenet_2', 'model_spec.json'))
+
+
+@pytest.fixture('session')
+def test_animals_model_path():
+    return os.path.abspath(os.path.join('tmp', 'fixtures', 'models', 'single', 'animals-mobilenet.hdf5'))
+
+
+@pytest.fixture('session')
+def test_animals_dictionary_path():
+    return os.path.abspath(os.path.join('tests', 'files', 'animals', 'dictionary.json'))
+
+
+@pytest.fixture('session')
+def test_animals_model_spec():
+    return os.path.abspath(os.path.join('tmp', 'fixtures', 'models', 'single', 'model_spec.json'))
+
+
+@pytest.fixture('session')
+def model_spec_mobilenet():
+    dataset_mean = [142.69182214, 119.05833338, 106.89884415]
+    return ModelSpec.get('mobilenet_v1', preprocess_func='mean_subtraction', preprocess_args=dataset_mean)
+
+
+@pytest.fixture('function')
+def evaluator_mobilenet(test_mobilenet_1_model_spec, test_catdog_mobilenet_model):
+    specs = {'klass': 'keras.applications.mobilenet.MobileNet',
+             'name': 'mobilenet_v1',
+             'preprocess_args': None,
+             'preprocess_func': 'between_plus_minus_1',
+             'target_size': [224, 224, 3]
+             }
+
+    with open(os.path.abspath(test_mobilenet_1_model_spec), 'w') as outfile:
+        json.dump(specs, outfile)
+
+    return Evaluator(
+        batch_size=1,
+        model_path=test_catdog_mobilenet_model
+    )
+
+
+@pytest.fixture('function')
+def evaluator_ensemble_mobilenet(test_mobilenet_1_model_spec, test_mobilenet_2_model_spec, test_ensemble_models_path):
+    specs = {'klass': 'keras.applications.mobilenet.MobileNet',
+             'name': 'mobilenet_v1',
+             'preprocess_args': None,
+             'preprocess_func': 'between_plus_minus_1',
+             'target_size': [224, 224, 3]
+             }
+
+    with open(os.path.abspath(test_mobilenet_1_model_spec), 'w') as outfile:
+        json.dump(specs, outfile)
+
+    with open(os.path.abspath(test_mobilenet_2_model_spec), 'w') as outfile:
+        json.dump(specs, outfile)
+
+    return Evaluator(
+        ensemble_models_dir=test_ensemble_models_path,
+        combination_mode='arithmetic',
+        batch_size=1
+    )
+
+
+@pytest.fixture('function')
+def evaluator_mobilenet_class_combine(test_animals_model_path, test_animals_dictionary_path, test_animals_model_spec):
+    specs = {'klass': 'keras.applications.mobilenet.MobileNet',
+             'name': 'mobilenet_v1',
+             'preprocess_args': [123.99345370133717, 116.22568321228027, 99.73750913143158],
+             'preprocess_func': 'mean_subtraction',
+             'target_size': [299, 299, 3]
+             }
+
+    with open(os.path.abspath(test_animals_model_spec), 'w') as outfile:
+        json.dump(specs, outfile)
+
+    return Evaluator(
+        batch_size=1,
+        model_path=test_animals_model_path,
+        concept_dictionary_path=test_animals_dictionary_path
+    )

--- a/tests/test_visualizer.py
+++ b/tests/test_visualizer.py
@@ -1,6 +1,7 @@
 import pytest
-from keras_eval.visualizer import plot_confusion_matrix, plot_concept_metrics, plot_threshold
 import numpy as np
+
+from keras_eval.visualizer import plot_confusion_matrix, plot_concept_metrics, plot_threshold
 
 
 def test_plot_confusion_matrix():


### PR DESCRIPTION
Fix https://github.com/triagemd/keras-eval/issues/81 by:
- Import mobilenet model from `keras.applications` instead of `keras_applications`
- `relu6` as Default custom objects is not needed anymore to load mobilenet models
- Retrain all the mobilenet models as wisely @jeremykawahara was proposing

Solve https://github.com/triagemd/keras-eval/pull/82 in this PR.

Some changes:
- Moved all the pytest fixtures to `conftest.py` 

TODO:
- Check if any other architectures still need Default custom objects to be imported. If it's not only mobilenet architecture, we could get rid of them. 