### PR TITLE
Add model specs files in fixtures

### DIFF
--- a/script/fetch-fixtures
+++ b/script/fetch-fixtures
@@ -4,20 +4,31 @@ set -e
 mkdir -p tmp/fixtures/models/ensemble/mobilenet_1/ tmp/fixtures/models/ensemble/mobilenet_2/
 
 cd tmp/fixtures/models/ensemble/mobilenet_1/
-  MODEL_URL="https://storage.googleapis.com/triage-lab/models/animals/catdog-mobilenet.hdf5"
+  MODEL_URL="https://storage.googleapis.com/triage-lab/models/animals/catdog-mobilenet/catdog-mobilenet.hdf5"
+  MODEL_SPEC_URL="https://storage.googleapis.com/triage-lab/models/animals/catdog-mobilenet/model_spec.json"
 if [ ! -f catdog-mobilenet.hdf5 ]; then
     wget $MODEL_URL
+fi
+if [ ! -f model_spec.json ]; then
+    wget $MODEL_SPEC_URL
 fi
 cd ../mobilenet_2/
 if [ ! -f catdog-mobilenet.hdf5 ]; then
     wget $MODEL_URL
+fi
+if [ ! -f model_spec.json ]; then
+    wget $MODEL_SPEC_URL
 fi
 )
 
 mkdir -p tmp/fixtures/models/single/
 
 cd tmp/fixtures/models/single/
+    MODEL_URL="https://storage.googleapis.com/triage-lab/models/animals/animals-mobilenet/animals-mobilenet.hdf5"
+    MODEL_SPEC_URL="https://storage.googleapis.com/triage-lab/models/animals/animals-mobilenet/model_spec.json"
 if [ ! -f animals-mobilenet.hdf5 ]; then
-    MODEL_URL="https://storage.googleapis.com/triage-lab/models/animals/animals-mobilenet.hdf5"
     wget $MODEL_URL
+fi
+if [ ! -f model_spec.json ]; then
+    wget $MODEL_SPEC_URL
 fi

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='keras-eval',
-    version='0.0.34',
+    version='0.0.35',
     description='An evaluation abstraction for Keras models.',
     author='Triage Technologies Inc.',
     author_email='ai@triage.com',

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     packages=find_packages(exclude=['tests', '.cache', '.venv', '.git', 'dist']),
     install_requires=[
         'Keras',
-	'numpy',
+	    'numpy',
         'h5py',
         'Pillow',
         'scipy',
@@ -22,6 +22,6 @@ setup(
         'matplotlib',
         'sklearn',
         'keras-model-specs>=0.0.28',
-	'setuptools==39.1.0'
+	    'setuptools==39.1.0'
     ]
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 import os
-import json
 import pytest
 
 from keras_eval.eval import Evaluator
@@ -53,11 +52,6 @@ def test_mobilenet_1_model_spec():
 
 
 @pytest.fixture('session')
-def test_mobilenet_2_model_spec():
-    return os.path.abspath(os.path.join('tmp', 'fixtures', 'models', 'ensemble', 'mobilenet_2', 'model_spec.json'))
-
-
-@pytest.fixture('session')
 def test_animals_model_path():
     return os.path.abspath(os.path.join('tmp', 'fixtures', 'models', 'single', 'animals-mobilenet.hdf5'))
 
@@ -68,28 +62,13 @@ def test_animals_dictionary_path():
 
 
 @pytest.fixture('session')
-def test_animals_model_spec():
-    return os.path.abspath(os.path.join('tmp', 'fixtures', 'models', 'single', 'model_spec.json'))
-
-
-@pytest.fixture('session')
 def model_spec_mobilenet():
     dataset_mean = [142.69182214, 119.05833338, 106.89884415]
     return ModelSpec.get('mobilenet_v1', preprocess_func='mean_subtraction', preprocess_args=dataset_mean)
 
 
 @pytest.fixture('function')
-def evaluator_mobilenet(test_mobilenet_1_model_spec, test_catdog_mobilenet_model):
-    specs = {'klass': 'keras.applications.mobilenet.MobileNet',
-             'name': 'mobilenet_v1',
-             'preprocess_args': None,
-             'preprocess_func': 'between_plus_minus_1',
-             'target_size': [224, 224, 3]
-             }
-
-    with open(os.path.abspath(test_mobilenet_1_model_spec), 'w') as outfile:
-        json.dump(specs, outfile)
-
+def evaluator_mobilenet(test_catdog_mobilenet_model):
     return Evaluator(
         batch_size=1,
         model_path=test_catdog_mobilenet_model
@@ -97,20 +76,7 @@ def evaluator_mobilenet(test_mobilenet_1_model_spec, test_catdog_mobilenet_model
 
 
 @pytest.fixture('function')
-def evaluator_ensemble_mobilenet(test_mobilenet_1_model_spec, test_mobilenet_2_model_spec, test_ensemble_models_path):
-    specs = {'klass': 'keras.applications.mobilenet.MobileNet',
-             'name': 'mobilenet_v1',
-             'preprocess_args': None,
-             'preprocess_func': 'between_plus_minus_1',
-             'target_size': [224, 224, 3]
-             }
-
-    with open(os.path.abspath(test_mobilenet_1_model_spec), 'w') as outfile:
-        json.dump(specs, outfile)
-
-    with open(os.path.abspath(test_mobilenet_2_model_spec), 'w') as outfile:
-        json.dump(specs, outfile)
-
+def evaluator_ensemble_mobilenet(test_ensemble_models_path):
     return Evaluator(
         ensemble_models_dir=test_ensemble_models_path,
         combination_mode='arithmetic',
@@ -119,17 +85,7 @@ def evaluator_ensemble_mobilenet(test_mobilenet_1_model_spec, test_mobilenet_2_m
 
 
 @pytest.fixture('function')
-def evaluator_mobilenet_class_combine(test_animals_model_path, test_animals_dictionary_path, test_animals_model_spec):
-    specs = {'klass': 'keras.applications.mobilenet.MobileNet',
-             'name': 'mobilenet_v1',
-             'preprocess_args': [123.99345370133717, 116.22568321228027, 99.73750913143158],
-             'preprocess_func': 'mean_subtraction',
-             'target_size': [299, 299, 3]
-             }
-
-    with open(os.path.abspath(test_animals_model_spec), 'w') as outfile:
-        json.dump(specs, outfile)
-
+def evaluator_mobilenet_class_combine(test_animals_model_path, test_animals_dictionary_path):
     return Evaluator(
         batch_size=1,
         model_path=test_animals_model_path,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -23,14 +23,14 @@ def test_read_dictionary(training_dict_file):
     assert actual == expected
 
 
-def test_load_model(test_catdog_mobilenet_model, test_mobilenet_2_model_spec):
+def test_load_model(test_catdog_mobilenet_model, test_mobilenet_1_model_spec):
 
     # Default model_spec
     model = utils.load_model(test_catdog_mobilenet_model)
     assert model
 
     # Custom model_spec
-    model = utils.load_model(test_catdog_mobilenet_model, specs_path=test_mobilenet_2_model_spec)
+    model = utils.load_model(test_catdog_mobilenet_model, specs_path=test_mobilenet_1_model_spec)
     assert model
 
 


### PR DESCRIPTION
Fix https://github.com/triagemd/keras-eval/issues/85

As you discussed in the issue, the `model_spec.json` for both models were created when doing `script/test test/test_eval`. If someone were trying to run the notebook without running the tests, then the files were missing.

Solution: add them as fixtures.