### PR TITLE
Add test data augmentation to readme & set testing versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: python
 sudo: required
 
-python:
-  - 3.6
+python: 3.6
 
 before_install:
   - script/up

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: python
 sudo: required
 
-python: 3.6
+python:
+  - "3.6"
 
 before_install:
   - script/up

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,15 @@ python:
 before_install:
   - script/up
 
-script:
-  - script/test
-
 jobs:
   include:
+    - stage: test
+      script:
+        - script/test
+
     - stage: distribute
+      python: "3.6"
       if: branch = master AND type != pull_request
       install: skip
-      python: "3.6"
       script:
         - script/distribute

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,11 @@ python:
 before_install:
   - script/up
 
+script:
+  - script/test
+
 jobs:
   include:
-    - stage: test
-      script:
-        - script/test
-
     - stage: distribute
       python: "3.6"
       if: branch = master AND type != pull_request

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 sudo: required
 
 python:
+  - "3.5"
   - "3.6"
 
 before_install:
@@ -15,5 +16,6 @@ jobs:
     - stage: distribute
       if: branch = master AND type != pull_request
       install: skip
+      python: "3.6"
       script:
         - script/distribute

--- a/README.md
+++ b/README.md
@@ -248,8 +248,8 @@ evaluator.add_model_ensemble(model_path)
 **set_concepts**
 
 ```
-concepts = [{'label':'Dog', 'id': 'dogs'},
-           {'label':'Cat', 'id': 'cats'}]
+concepts = [{'label':'Cat', 'id': 'cats'},
+            {'label':'Dog', 'id': 'dogs'},]
 
 evaluator.set_concepts(concepts)
 ```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Evaluation abstraction for Keras models. [Example Notebook](https://github.com/triagemd/keras-eval/blob/master/example.ipynb)
 
-Requires [keras-model-specs](https://github.com/triagemd/keras-model-specs).
+Requires [keras-model-specs](https://github.com/triagemd/keras-model-specs). We support python 3+.
 
 # Example Evaluation
 
@@ -71,6 +71,26 @@ ensemble_models_dir = '/model_folder'
 # e.g. '/model_folder/resnet_50/model.h5', '/model_folder/resnet_50/model_spec.json', '/model_folder/densenet201/model.h5', '/model_folder/densenet201/model_spec.json'
 
 ```
+
+**Apply Data Augmentation at Test time**
+
+We include the addition of data_augmentation as an argument in evaluate. It is a dictionary consisting of 3 elements:
+    
+- 'scale_sizes': 'default' (4 similar scales to Original paper) or a list of sizes. Each scaled image then
+    will be cropped into three square parts.
+- 'transforms': list of transforms to apply to these crops in addition to not
+    applying any transform ('horizontal_flip', 'vertical_flip', 'rotate_90', 'rotate_180', 'rotate_270' are
+    supported now).
+- 'crop_original': 'center_crop' mode allows to center crop the original image prior do the rest of transforms,
+    scalings + croppings.
+    
+For instance:
+
+```
+probs, labels = evaluator.evaluate(data_dir=data_dir, top_k=2, confusion_matrix=True, data_augmentation={'scale_sizes': [356, 284], 'transforms': ['horizontal_flip'], 'crop_original': 'center_crop'})
+
+```
+
 **To evaluate on coarse classes after training on granular classes**
 
 Given a model trained on M classes and test set based on N classes (M > N), allow the evaluation on sets of classes by providing a *concept dictionary*.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ ensemble_models_dir = '/model_folder'
 
 **Apply Data Augmentation at Test time**
 
-We include the addition of data_augmentation as an argument in evaluate. It is a dictionary consisting of 3 elements:
+We include the addition of `data_augmentation` as an argument in `evaluate`. It is a dictionary consisting of 3 elements:
     
 - 'scale_sizes': 'default' (4 similar scales to Original paper) or a list of sizes. Each scaled image then
     will be cropped into three square parts.

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='keras-eval',
-    version='1.0.0',
+    version='1.0.1',
     description='An evaluation abstraction for Keras models.',
     author='Triage Technologies Inc.',
     author_email='ai@triage.com',


### PR DESCRIPTION
Following https://github.com/travis-ci/travis-ci/issues/8536 we have 2 options or test more than one python version or put the test inside jobs. 
I decided to run tests on python 3.5 and 3.6. Let me know what you think :). 