### PR TITLE
Add costumized generator support

### DIFF
--- a/keras_eval/eval.py
+++ b/keras_eval/eval.py
@@ -25,6 +25,7 @@ class Evaluator(object):
         'batch_size': {'type': int, 'default': 1},
         'verbose': {'type': int, 'default': 0},
         'data_augmentation': {'type': dict, 'default': None},
+        'data_generator':{'type':ImageDataGenerator, 'default': None},
     }
 
     def __init__(self, **options):

--- a/keras_eval/eval.py
+++ b/keras_eval/eval.py
@@ -7,6 +7,7 @@ import keras_eval.visualizer as visualizer
 
 from math import log
 from keras.utils import generic_utils
+from keras.preprocessing.image import ImageDataGenerator
 
 
 class Evaluator(object):

--- a/keras_eval/eval.py
+++ b/keras_eval/eval.py
@@ -271,28 +271,36 @@ class Evaluator(object):
         else:
             for i, model in enumerate(self.models):
                 print('Making predictions from model ', str(i))
-                if data_augmentation is None:
-                    generator, labels = utils.create_image_generator(data_dir, self.batch_size, self.model_specs[i])
-                    # N_batches + 1 to gather all the images + collect without repetition [0:n_samples]
+                if self.data_generator is None:
+                    # build generator
+                    if data_augmentation is None:
+                        generator, labels = utils.create_image_generator(data_dir, self.batch_size, self.model_specs[i])
+                        # N_batches + 1 to gather all the images + collect without repetition [0:n_samples]
+                        probabilities.append(model.predict_generator(generator=generator,
+                                                                     steps=(generator.samples // self.batch_size) + 1,
+                                                                     workers=1,
+                                                                     verbose=1)[0:generator.samples])
+                    else:
+                        generator, labels = utils.create_image_generator(data_dir, self.batch_size, self.model_specs[i],
+                                                                         data_augmentation=data_augmentation)
+                        print('Averaging probabilities of %i different outputs at sizes: %s with transforms: %s'
+                              % (generator.n_crops, generator.scale_sizes, generator.transforms))
+                        steps = generator.samples
+                        probabilities_model = []
+                        for k, batch in enumerate(generator):
+                            if k == steps:
+                                break
+                            progbar = generic_utils.Progbar(steps)
+                            progbar.add(k + 1)
+                            probs = model.predict(batch[0][0], batch_size=self.batch_size)
+                            probabilities_model.append(np.mean(probs, axis=0))
+                        probabilities.append(probabilities_model)
+                else:
+                    generator, labels = utils.import_image_generator(data_dir, self.batch_size, self.model_specs[i], self.data_generator)
                     probabilities.append(model.predict_generator(generator=generator,
                                                                  steps=(generator.samples // self.batch_size) + 1,
                                                                  workers=1,
                                                                  verbose=1)[0:generator.samples])
-                else:
-                    generator, labels = utils.create_image_generator(data_dir, self.batch_size, self.model_specs[i],
-                                                                     data_augmentation=data_augmentation)
-                    print('Averaging probabilities of %i different outputs at sizes: %s with transforms: %s'
-                          % (generator.n_crops, generator.scale_sizes, generator.transforms))
-                    steps = generator.samples
-                    probabilities_model = []
-                    for k, batch in enumerate(generator):
-                        if k == steps:
-                            break
-                        progbar = generic_utils.Progbar(steps)
-                        progbar.add(k + 1)
-                        probs = model.predict(batch[0][0], batch_size=self.batch_size)
-                        probabilities_model.append(np.mean(probs, axis=0))
-                    probabilities.append(probabilities_model)
 
             self.generator = generator
             self.num_classes = generator.num_classes

--- a/keras_eval/eval.py
+++ b/keras_eval/eval.py
@@ -25,7 +25,7 @@ class Evaluator(object):
         'batch_size': {'type': int, 'default': 1},
         'verbose': {'type': int, 'default': 0},
         'data_augmentation': {'type': dict, 'default': None},
-        'data_generator':{'type':ImageDataGenerator, 'default': None},
+        'data_generator': {'type': ImageDataGenerator, 'default': None},
     }
 
     def __init__(self, **options):

--- a/keras_eval/utils.py
+++ b/keras_eval/utils.py
@@ -284,7 +284,7 @@ def import_image_generator(data_dir, batch_size, model_spec, data_gen):
         preprocessing_function: Function to preprocess the images
         target_size: Size of the images
         data_gen: The imported data generator
-        
+
     Returns: Keras generator without shuffling samples and ground truth labels associated with generator
     '''
     print('Input image size: ', model_spec.target_size)

--- a/keras_eval/utils.py
+++ b/keras_eval/utils.py
@@ -276,6 +276,26 @@ def create_image_generator(data_dir, batch_size, model_spec, data_augmentation=N
     return generator, labels
 
 
+def import_image_generator(data_dir, batch_size, model_spec, data_gen):
+    '''
+    Creates a Keras image generator
+    Args:
+        batch_size: N images per batch
+        preprocessing_function: Function to preprocess the images
+        target_size: Size of the images
+        data_gen: The imported data generator
+        
+    Returns: Keras generator without shuffling samples and ground truth labels associated with generator
+    '''
+    print('Input image size: ', model_spec.target_size)
+    generator = data_gen.flow_from_directory(data_dir, batch_size=batch_size, target_size=model_spec.target_size[:2],
+                                             class_mode='categorical', shuffle=False)
+
+    labels = keras.utils.np_utils.to_categorical(generator.classes, generator.num_classes)
+
+    return generator, labels
+
+
 def load_preprocess_image(img_path, model_spec):
     """
     Return a preprocessed image (probably to use within a deep neural net).


### PR DESCRIPTION
I made a few changes to let `keras_eval` to support a customized data generator by just adding a member called `data_generator`. So you can just call 
```
Evaluator(data_generator=your_own_data_generator) 
```
for evaluation now.

Also @jsalbert can you take a look at this [commit](https://github.com/triagemd/keras-eval/commit/7e832c5b63a662be20ebce878b1735820e9c8afb#diff-2ec13b1be8f785d968e571933660ecae) to make sure that this won't break your previous code.
